### PR TITLE
Update CreateAccount.jsx

### DIFF
--- a/src/Components/CreateAccount.jsx
+++ b/src/Components/CreateAccount.jsx
@@ -97,7 +97,7 @@ class CreateAccount extends Component {
       "is_staff": false,
       "is_superuser": false
     });
-    fetch(this.env.getRootUrl() + "/users/", {
+    fetch(this.env.getRootUrl() + "/api-auth/register/", {
       method: "POST",
       body: json,
       headers: {


### PR DESCRIPTION
closes #79 but introduces or exposes a new issue in that the new end point does not return access tokens which we believe should be fixed in a different PR. Currently creating a user will show that an error occured, but if watching for a response you will see that the user was actually created and can be used to log in. Matt G and I decided it was better to fix this minor issue so that people can create users again and then we can decide as a team how to fix the rest.