### PR TITLE
dont allow the class calendar to override the landing page background

### DIFF
--- a/src/Components/ClassCalendar.css
+++ b/src/Components/ClassCalendar.css
@@ -1,4 +1,4 @@
-.container-fluid {
+.calendarBackground {
   background-image: url(/CalChalk.jpeg);
   background-repeat: no-repeat;
   background-size: cover;

--- a/src/Components/ClassCalendar.jsx
+++ b/src/Components/ClassCalendar.jsx
@@ -65,7 +65,7 @@ class ClassCalendar extends Component {
     return (
       <div>
         <Menubar />
-        <Container fluid>
+        <Container className="calendarBackground" fluid>
           <Row>
             <Col>
               <h1>My Calendar</h1>


### PR DESCRIPTION
fix the landing page to show the correct background again