### PR TITLE
Make roster page pretty

### DIFF
--- a/src/Components/Roster.css
+++ b/src/Components/Roster.css
@@ -7,7 +7,6 @@
 }
 
 .addTeacherHeading {
-  float: left;
   background-repeat: no-repeat;
   font-family: Chalkduster, sans-serif;
   font-weight: bold;
@@ -15,7 +14,6 @@
 }
 
 .teacherMenu {
-  float: left;
   background-repeat: no-repeat;
   font-family: Chalkduster, sans-serif;
   font-weight: bold;
@@ -29,7 +27,6 @@
 }
 
 .teacherField {
-  float: right;
   opacity: 0.8;
   background-repeat: no-repeat;
   font-family: Chalkduster, sans-serif;
@@ -38,7 +35,6 @@
 }
 
 .addStudentHeading {
-  float: left;
   background-repeat: no-repeat;
   font-family: Chalkduster, sans-serif;
   font-weight: bold;
@@ -46,7 +42,6 @@
 }
 
 .studentMenu {
-  float: left;
   background-repeat: no-repeat;
   font-family: Chalkduster, sans-serif;
   font-weight: bold;
@@ -54,7 +49,6 @@
 }
 
 .studentField {
-  float: right;
   opacity: 0.8;
   background-repeat: no-repeat;
   font-family: Chalkduster, sans-serif;
@@ -80,8 +74,6 @@
 }
 
 .txtInputButton {
-  margin-right: 270px;
-  margin-left: 200px;
   background-repeat: no-repeat;
   font-family: Chalkduster, sans-serif;
   font-weight: bold;

--- a/src/Components/Roster.css
+++ b/src/Components/Roster.css
@@ -1,41 +1,73 @@
-.background_roster {
-  background-color: #dedee6;
+.backgroundRosterPage {
+  background-image: url(/fpbackground.jpg);
+  background-repeat: no-repeat;
+  background-size:cover;
+  background-color: #6a6a73;
+  min-height: 100vh;
 }
 
 .addTeacherHeading {
   float: left;
+  background-repeat: no-repeat;
+  font-family: Chalkduster, sans-serif;
+  font-weight: bold;
+  color: white;
 }
 
 .teacherMenu {
   float: left;
+  background-repeat: no-repeat;
+  font-family: Chalkduster, sans-serif;
+  font-weight: bold;
+  color: white;
+}
+
+.dropdownScroll {
+  height: 300px;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 .teacherField {
   float: right;
-  padding: 10px;
-  background-color: #759f5d;
-  border: 1px black solid;
   opacity: 0.8;
+  background-repeat: no-repeat;
+  font-family: Chalkduster, sans-serif;
+  font-weight: bold;
+  color: white;
 }
 
 .addStudentHeading {
   float: left;
+  background-repeat: no-repeat;
+  font-family: Chalkduster, sans-serif;
+  font-weight: bold;
+  color: white;
 }
 
 .studentMenu {
   float: left;
+  background-repeat: no-repeat;
+  font-family: Chalkduster, sans-serif;
+  font-weight: bold;
+  color: white;
 }
 
 .studentField {
   float: right;
-  padding: 10px;
-  background-color: #759f5d;
-  border: 1px black solid;
   opacity: 0.8;
+  background-repeat: no-repeat;
+  font-family: Chalkduster, sans-serif;
+  font-weight: bold;
+  color: white;
 }
 
 .inputBox {
   text-align: center;
+  background-repeat: no-repeat;
+  font-family: Chalkduster, sans-serif;
+  font-weight: bold;
+  color: white;
 }
 
 .flex {
@@ -50,9 +82,26 @@
 .txtInputButton {
   margin-right: 270px;
   margin-left: 200px;
+  background-repeat: no-repeat;
+  font-family: Chalkduster, sans-serif;
+  font-weight: bold;
+  color: white;
 }
 
 input[type="text"] {
   background-color: #dedee6;
   border: 0px;
+}
+
+.textLabelRosterPage {
+  font-size: 20px;
+  background-repeat: no-repeat;
+  font-family: Chalkduster, sans-serif;
+  font-weight: bold;
+  color: white;
+}
+
+.createRosterButton {
+  font-size: 28px !important;
+  font-family: Chalkduster, sans-serif;
 }

--- a/src/Components/Roster.jsx
+++ b/src/Components/Roster.jsx
@@ -55,7 +55,7 @@ const CustomMenu = React.forwardRef(
         <ul className="list-unstyled">
           {React.Children.toArray(children).filter(
             (child) =>
-              !value || child.props.children.toLowerCase().startsWith(value),
+              !value || child.props.children.toLowerCase().includes(value),
           )}
         </ul>
       </div>
@@ -261,20 +261,20 @@ class Roster extends Component {
     return (
       <div >
         <Menubar />
-        <Container className="background_roster" fluid>
+        <Container fluid className={'backgroundRosterPage'}>
+          <br />
           <Row className="justify-content-md-center">
             <Col xs={5}>
-              <br />
-              <h2 id="pageTitle_roster"> </h2>
+              <h2 className="textLabelRosterPage" id="pageTitle_roster"> </h2>
             </Col>
           </Row>
-          <br />
           <br />
           <Row className="justify-content-md-center">
             <Col xs={5}>
               <Form.Control
                 type="text"
                 name="rosterName"
+                className="textLabelRosterPage"
                 value={this.state.rosterName}
                 onChange={this.rosterNameChange}
                 placeholder="Roster Name"
@@ -297,7 +297,7 @@ class Roster extends Component {
                 <Dropdown.Toggle as={CustomToggle} id="dropdown-custom-components">
                   Co-Teacher's Name(s)
                 </Dropdown.Toggle>
-                <Dropdown.Menu as={CustomMenu}>
+                <Dropdown.Menu className="dropdownScroll" as={CustomMenu}>
                   {
                     Object.keys(this.eligibleTeachers).map(teacher => {
                       var participant = this.eligibleTeachers[teacher];
@@ -321,6 +321,7 @@ class Roster extends Component {
               </Form>
             </Col>
           </Row>
+          <br />
           <Row className="justify-content-md-center">
             <Col xs={5}>
               <h4 className="addStudentHeading"> Add Student(s)</h4>
@@ -335,7 +336,7 @@ class Roster extends Component {
                 <Dropdown.Toggle as={CustomToggle} id="dropdown-custom-components">
                   Student's Name(s)
                 </Dropdown.Toggle>
-                <Dropdown.Menu as={CustomMenu}>
+                <Dropdown.Menu className="dropdownScroll" as={CustomMenu}>
                   {
                     Object.keys(this.eligibleStudents).map(student => {
                       var participant = this.eligibleStudents[student];
@@ -361,7 +362,7 @@ class Roster extends Component {
           </Row>
           <Row className="justify-content-md-center">
             <Col xs={12} md={6}>
-              <Button onClick={this.prepareFinalRoster}>Click to Complete Roster</Button>
+              <Button variant="light" className="createRosterButton" onClick={this.prepareFinalRoster}>Click to Complete Roster</Button>
             </Col>
           </Row>
         </Container>

--- a/src/Components/Roster.jsx
+++ b/src/Components/Roster.jsx
@@ -264,13 +264,13 @@ class Roster extends Component {
         <Container fluid className={'backgroundRosterPage'}>
           <br />
           <Row className="justify-content-md-center">
-            <Col xs={5}>
+            <Col xs={10}>
               <h2 className="textLabelRosterPage" id="pageTitle_roster"> </h2>
             </Col>
           </Row>
           <br />
           <Row className="justify-content-md-center">
-            <Col xs={5}>
+            <Col xs={10} md={5}>
               <Form.Control
                 type="text"
                 name="rosterName"
@@ -360,6 +360,7 @@ class Roster extends Component {
               </Form>
             </Col>
           </Row>
+          <br />
           <Row className="justify-content-md-center">
             <Col xs={12} md={6}>
               <Button variant="light" className="createRosterButton" onClick={this.prepareFinalRoster}>Click to Complete Roster</Button>


### PR DESCRIPTION
closes #135 

updated the look of the roster page to be the same as the rest of the pages
![image](https://user-images.githubusercontent.com/49885138/109543142-f7235080-7a93-11eb-9985-30d58ed74328.png)

updated the search capability to not only search with starts with but now is contains
![image](https://user-images.githubusercontent.com/49885138/109543249-102c0180-7a94-11eb-9d0f-00011daf3eb1.png)

updated the dropdown to be to contain a scroll bar so it doesnt go bigger than the page
![image](https://user-images.githubusercontent.com/49885138/109543326-1fab4a80-7a94-11eb-9715-4882f6a78221.png)
