### PR TITLE
better roster error handling 

### DIFF
--- a/src/Components/Roster.jsx
+++ b/src/Components/Roster.jsx
@@ -246,12 +246,18 @@ class Roster extends Component {
       }).then((resp) => resp.json())
         .then((results) => {
           if (RefreshToken(results)) {
-            this.laddaButton.stop();
-            toastr.success('Created Class Roster', "Created your roster. You must now associate it with a class when ready.")
-            this.props.history.push({
-              pathname: '/Calendar',
-              state: { classId: results.class_id }
-            })
+            if (results.roster_id) {
+              this.laddaButton.stop();
+              toastr.success('Created Class Roster', "Created your roster. You must now associate it with a class when ready.")
+              this.props.history.push({
+                pathname: '/Calendar',
+                state: { classId: results.class_id }
+              })
+            }
+            else {
+              this.laddaButton.stop();
+              toastr.error('Error', "Failed to create roster. Please check network traffic for error information", "Error")
+            }
           }
           else {
             this.laddaButton.stop();


### PR DESCRIPTION
closes #152 

if we fail to create the roster dont tell the user we created it and redirect to calendar.  stay on roster and post error message.
this is done by checking that the response of the post call has roster_id