### PR TITLE
add create roster to menu bar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,9 +33,9 @@ function App() {
   return (
 
     <div className="App">
-        <Helmet>
-          <title>{ 'Recess' }</title>
-        </Helmet>
+      <Helmet>
+        <title>{'Recess'}</title>
+      </Helmet>
 
       <BrowserRouter>
         <Switch>
@@ -51,7 +51,7 @@ function App() {
           <Route exact path="/Logout" component={LogoutPage} />
           <Route exact path="/Calendar" component={Calendar} />
           <Route exact path="/ChangePassword" component={ChangePassword} />
-          <Route exact path="/Roster" component={Roster} />
+          <Route exact path="/CreateRoster" component={Roster} />
         </Switch>
       </BrowserRouter>
       <Provider store={store}>

--- a/src/Components/MenuBar.js
+++ b/src/Components/MenuBar.js
@@ -15,6 +15,7 @@ class Menubar extends React.Component {
                         <Nav.Link href="/About">About</Nav.Link>
                         <Nav.Link href="/Calendar" hidden={sessionStorage.getItem("accessToken") === null ? true : false}>Calendar</Nav.Link>
                         <Nav.Link href="/CreateEvent" hidden={sessionStorage.getItem("role") !== "Teacher" ? true : false}>New Class</Nav.Link>
+                        <Nav.Link href="/CreateRoster" hidden={sessionStorage.getItem("role") !== "Teacher" ? true : false}>New Roster</Nav.Link>
                     </Nav>
                     <Nav>
                         <Nav.Link href="/Profile" hidden={sessionStorage.getItem("accessToken") === null ? true : false}>Profile</Nav.Link>

--- a/src/Components/Roster.jsx
+++ b/src/Components/Roster.jsx
@@ -95,8 +95,22 @@ class Roster extends Component {
 
   componentDidMount() {
     this.laddaButton = Ladda.create(document.querySelector('#createRosterButton'));
-    this.populatePageTitle_roster();
-    this.loadEligibleParticipants();
+    if (!sessionStorage.getItem("refreshToken")) {
+      this.props.history.push({
+        pathname: '/login'
+      });
+    }
+    else {
+      if (sessionStorage.getItem("role") !== "Teacher") {
+        this.props.history.push({
+          pathname: '/Calendar'
+        });
+      }
+      else {
+        this.populatePageTitle_roster();
+        this.loadEligibleParticipants();
+      }
+    }
   }
 
   loadEligibleParticipants() {


### PR DESCRIPTION
closes #154 

rename url to CreateRoster.  
only allow authenticated teachers to acces the create roster page.  
add create roster to the menu bar
if a non teacher or someone who isnt logged in tries to go to the create roster page we now redirect to either the calendar or the login page

![image](https://user-images.githubusercontent.com/49885138/109884859-a9e9df00-7c4b-11eb-948e-0ab0d486d3d9.png)
